### PR TITLE
Remove AQI from forecast

### DIFF
--- a/WeatherAPI-CSharp.Tests/APITests.cs
+++ b/WeatherAPI-CSharp.Tests/APITests.cs
@@ -39,9 +39,9 @@ public class APITests
 	[Fact]
 	public async Task TestGetWeatherForecastDailyAsync()
 	{
-		const int days = 5;
+		const int days = 3;
 		var client = new APIClient(apiKey, true);
-		var weather = await client.GetWeatherForecastDailyAsync("Berlin", days, true);
+		var weather = await client.GetWeatherForecastDailyAsync("Berlin", days);
 
 		Assert.Equal(days, weather.Length);
 
@@ -51,7 +51,6 @@ public class APITests
 			output.WriteLine(forecast.ToString());
 
 			Assert.True(forecast.Valid);
-			Assert.True(forecast.AirQuality.Valid || index > 2);
 			Assert.InRange(forecast.AvgTemperatureCelsius, -100, 100);
 			Assert.NotEmpty(forecast.ConditionText);
 			Assert.InRange(forecast.MaxWindKph, 0, 200);
@@ -70,16 +69,15 @@ public class APITests
 			output.WriteLine(forecast.ToString());
 
 			Assert.False(forecast.Valid);
-			Assert.False(forecast.AirQuality.Valid);
 		}
 	}
 
 	[Fact]
 	public async Task TestGetWeatherForecastHourlyAsync()
 	{
-		const int hours = 24 * 12;
+		const int hours = 24 * 3;
 		var client = new APIClient(apiKey, true);
-		var weather = await client.GetWeatherForecastHourlyAsync("Berlin", hours, true);
+		var weather = await client.GetWeatherForecastHourlyAsync("Berlin", hours);
 
 		Assert.Equal(hours, weather.Length);
 
@@ -89,7 +87,6 @@ public class APITests
 			output.WriteLine(forecast.ToString());
 
 			Assert.True(forecast.Valid);
-			Assert.True(forecast.AirQuality.Valid || Math.Ceiling(index / 24d) > 2);
 			Assert.InRange(forecast.TemperatureCelsius, -100, 100);
 			Assert.NotEmpty(forecast.ConditionText);
 			Assert.InRange(forecast.WindKph, 0, 200);
@@ -108,7 +105,6 @@ public class APITests
 			output.WriteLine(forecast.ToString());
 
 			Assert.False(forecast.Valid);
-			Assert.False(forecast.AirQuality.Valid);
 		}
 	}
 }

--- a/WeatherAPI-CSharp/Forecast/ForecastDaily.cs
+++ b/WeatherAPI-CSharp/Forecast/ForecastDaily.cs
@@ -57,10 +57,8 @@ public readonly struct ForecastDaily
 	public int ConditionCode { get; }
 	/// <value>UV Index</value>
 	public double UV { get; }
-	/// <value><see cref="AirQuality"/> data</value>
-	public AirQuality AirQuality { get; }
 
-	internal ForecastDaily(dynamic jsonData, bool airQuality)
+	internal ForecastDaily(dynamic jsonData)
 	{
 		Valid = true;
 		Date = jsonData.date;
@@ -87,13 +85,6 @@ public readonly struct ForecastDaily
 		ConditionIconUrl = jsonData.day.condition.icon;
 		ConditionCode = jsonData.day.condition.code;
 		UV = jsonData.day.uv;
-		if (airQuality)
-		{
-			AirQuality = new AirQuality(jsonData.day.air_quality);
-			return;
-		}
-
-		AirQuality = default;
 	}
 
 	/// <summary>

--- a/WeatherAPI-CSharp/Forecast/ForecastHourly.cs
+++ b/WeatherAPI-CSharp/Forecast/ForecastHourly.cs
@@ -79,10 +79,8 @@ public readonly struct ForecastHourly
 	public double GustMph { get; }
 	/// <value>UV Index</value>
 	public double UV { get; }
-	/// <value><see cref="AirQuality"/> data</value>
-	public AirQuality AirQuality { get; }
 
-	internal ForecastHourly(dynamic jsonData, bool airQuality)
+	internal ForecastHourly(dynamic jsonData)
 	{
 		Valid = true;
 		Date = jsonData.time;
@@ -120,12 +118,6 @@ public readonly struct ForecastHourly
 		GustKph = jsonData.gust_kph;
 		GustMph = jsonData.gust_mph;
 		UV = jsonData.uv;
-		if (airQuality)
-		{
-			AirQuality = new AirQuality(jsonData.air_quality);
-			return;
-		}
-		AirQuality = default;
 	}
 
 	/// <summary>

--- a/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
+++ b/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
@@ -6,13 +6,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>WeatherAPI-CSharp</PackageId>
-    <Version>0.4.1</Version>
+    <Version>0.4.3</Version>
     <PackageTags>CSharp</PackageTags>
     <Description>
       This is a small wrapper library to be used with the weatherapi.com API. It is a much simpler alternative to the official library, with the goal to make building any kind of weather app much simpler.
     </Description>
     <Authors>Skratymir</Authors>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/Skratymir/WeatherAPI-CSharp</RepositoryUrl>

--- a/WeatherAPI-CSharp/WeatherAPIClient.cs
+++ b/WeatherAPI-CSharp/WeatherAPIClient.cs
@@ -1,5 +1,5 @@
-using Newtonsoft.Json;
 using System.Net;
+using Newtonsoft.Json;
 
 /// <summary>
 /// Holds all classes needed to make API requests
@@ -47,7 +47,7 @@ public class APIClient
 
 			return new Forecast(jsonData.current, getAirData);
 		}
-		catch(HttpRequestException e)
+		catch (HttpRequestException e)
 		{
 			System.Diagnostics.Debug.WriteLine(e.StatusCode switch
 			{
@@ -66,12 +66,11 @@ public class APIClient
 	/// </summary>
 	/// <param name="query">Weather location</param>
 	/// <param name="days">Amount of days to get the forecast for</param>
-	/// <param name="getAirData">Wether or not to get air quality data</param>
 	/// <returns>Array of <see cref="ForecastDaily"/> classes</returns>
 	/// <remarks>Returns default on http error. In this case, ForecastDaily[0].Valid will be false.</remarks>
-	public async Task<ForecastDaily[]> GetWeatherForecastDailyAsync(string query, int days = 7, bool getAirData = false)
+	public async Task<ForecastDaily[]> GetWeatherForecastDailyAsync(string query, int days = 3)
 	{
-		var uri = new Uri($"{(_useHttps ? "https" : "http")}://api.weatherapi.com/v1/forecast.json?key={_apiKey}&q={query}&days={days}&aqi={(getAirData ? "yes" : "no")}");
+		var uri = new Uri($"{(_useHttps ? "https" : "http")}://api.weatherapi.com/v1/forecast.json?key={_apiKey}&q={query}&days={days}");
 
 		using var client = new HttpClient();
 
@@ -88,13 +87,13 @@ public class APIClient
 
 			foreach (var dailyData in jsonData.forecast.forecastday)
 			{
-				forecasts[index] = new ForecastDaily(dailyData, index <= 2 && getAirData);
+				forecasts[index] = new ForecastDaily(dailyData);
 				index++;
 			}
 
 			return forecasts;
 		}
-		catch(HttpRequestException e)
+		catch (HttpRequestException e)
 		{
 			System.Diagnostics.Debug.WriteLine(e.StatusCode switch
 			{
@@ -104,7 +103,7 @@ public class APIClient
 				HttpStatusCode.NotFound => "Error 404 - Not Found.",
 				_ => $"Error {e.StatusCode}"
 			});
-			return new ForecastDaily[]{default};
+			return new ForecastDaily[] { default };
 		}
 	}
 
@@ -113,12 +112,11 @@ public class APIClient
 	/// </summary>
 	/// <param name="query">Weather location</param>
 	/// <param name="hours">Amount of hours to get the forecast for</param>
-	/// <param name="getAirData">Wether or not to get air quality data</param>
 	/// <returns>Array of <see cref="ForecastHourly"/> classes</returns>
 	/// <remarks>Returns default on http error. In this case, ForecastHourly[0].Valid will be false.</remarks>
-	public async Task<ForecastHourly[]> GetWeatherForecastHourlyAsync(string query, int hours = 24, bool getAirData = false)
+	public async Task<ForecastHourly[]> GetWeatherForecastHourlyAsync(string query, int hours = 24)
 	{
-		var uri = new Uri($"{(_useHttps ? "https" : "http")}://api.weatherapi.com/v1/forecast.json?key={_apiKey}&q={query}&days={Math.Ceiling(hours / 24d)}&aqi={(getAirData ? "yes" : "no")}");
+		var uri = new Uri($"{(_useHttps ? "https" : "http")}://api.weatherapi.com/v1/forecast.json?key={_apiKey}&q={query}&days={Math.Ceiling(hours / 24d)}");
 
 		using var client = new HttpClient();
 
@@ -137,7 +135,7 @@ public class APIClient
 			{
 				foreach (var hourlyData in dailyData.hour)
 				{
-					forecasts[index] = new ForecastHourly(hourlyData, Math.Ceiling((index + 1) / 24d) <= 3 && getAirData);
+					forecasts[index] = new ForecastHourly(hourlyData);
 					index++;
 					if (index == hours)
 						return forecasts;
@@ -146,7 +144,7 @@ public class APIClient
 
 			return forecasts;
 		}
-		catch(HttpRequestException e)
+		catch (HttpRequestException e)
 		{
 			System.Diagnostics.Debug.WriteLine(e.StatusCode switch
 			{
@@ -156,7 +154,7 @@ public class APIClient
 				HttpStatusCode.NotFound => "Error 404 - Not Found.",
 				_ => $"Error {e.StatusCode}"
 			});
-			return new ForecastHourly[]{default};
+			return new ForecastHourly[] { default };
 		}
 	}
 }


### PR DESCRIPTION
Due to some unknown reason, air quality data does not appear to exist inside of forecast data anymore, only in the current forecast. Because of this, I removed the option to get AQI from all forecasts.

I also changed the default amount of days and hours to get forecast data for to an amount available to the free weatherapi.com plan.