### PR TITLE
Add .NET 9 support and update vulnerable dependencies

### DIFF
--- a/WeatherAPI-CSharp.Example/WeatherAPI-CSharp.Example.csproj
+++ b/WeatherAPI-CSharp.Example/WeatherAPI-CSharp.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp.Example</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/WeatherAPI-CSharp.Example/WeatherAPI-CSharp.Example.csproj
+++ b/WeatherAPI-CSharp.Example/WeatherAPI-CSharp.Example.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp.Example</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/WeatherAPI-CSharp.Tests/APITests.cs
+++ b/WeatherAPI-CSharp.Tests/APITests.cs
@@ -122,7 +122,11 @@ public class APITests
 	public async Task TestGetCurrentDataWithIpLookup()
 	{
 		var client = new APIClient(apiKey, true);
-		var weather = await client.GetWeatherCurrentAsync(client.GetLocationDataByIpAsync().Result.City, true);
+		var location = await client.GetLocationDataByIpAsync();
+
+		Assert.True(location.Valid);
+
+		var weather = await client.GetWeatherCurrentAsync($"{location.Latitude},{location.Longitude}", true);
 
 		output.WriteLine(weather.ToString());
 

--- a/WeatherAPI-CSharp.Tests/WeatherAPI-CSharp.Tests.csproj
+++ b/WeatherAPI-CSharp.Tests/WeatherAPI-CSharp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/WeatherAPI-CSharp.Tests/WeatherAPI-CSharp.Tests.csproj
+++ b/WeatherAPI-CSharp.Tests/WeatherAPI-CSharp.Tests.csproj
@@ -1,12 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
+++ b/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>WeatherAPI-CSharp</PackageId>
-    <Version>0.5.4</Version>
+    <Version>0.5.5</Version>
     <PackageTags>CSharp</PackageTags>
     <Description>
       This is a small wrapper library to be used with the weatherapi.com API. It is a much simpler alternative to the official library, with the goal to make building any kind of weather app much simpler.

--- a/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
+++ b/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
+++ b/WeatherAPI-CSharp/WeatherAPI-CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>WeatherAPI_CSharp</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -22,6 +22,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>
     <None Include="../LICENSE.md" Pack="true" PackagePath="" />


### PR DESCRIPTION
Add .NET 9 support and drop support for EOL versions (.NET 6 and .NET 7)
Also fix vulnerabilities by updating dependencies.